### PR TITLE
add method to filter the divides 

### DIFF
--- a/partitioning/core.py
+++ b/partitioning/core.py
@@ -108,7 +108,6 @@ def _check_altitude_rage(gpd_obj):
         gpd_obj, bool = _merge_sliver(gpd_obj, geom.geometry)
     return gpd_obj
 
-
 def _check_contain_divides(glacier_poly, id):
     """
     check if any object from glacier_poly contains glacier_poly.loc[id,


### PR DESCRIPTION
 The following divides could be filtered out, if the corresponding boolean is set on True:

-  divides with an area smaller than 2% of the largest divide (default: False)
- divides with an altitude range smaller than 10% of the glaciers total altitude range (default: True)
- divides with an absolute altitude range smaller than 100m (default: True)